### PR TITLE
Add contentful-schema-diff to list of utilities

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -11,5 +11,11 @@
   {
     "title": "Awesome Starters",
     "items": ["whitep4nth3r/thingoftheday"]
+  },
+  {
+    "title": "Awesome Utilities",
+    "items": [
+       "watermarkchurch/contentful-schema-diff
+    ]
   }
 ]


### PR DESCRIPTION
https://github.com/watermarkchurch/contentful-schema-diff is in use by several people to automatically generate a Contentful migration based on the difference between two spaces, or two environments inside a single space.  It is a core part of our workflow at Watermark Community Church.