### PR TITLE
Add "watermarkchurch/contentful-shell"

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -15,7 +15,8 @@
   {
     "title": "Awesome Utilities",
     "items": [
-       "watermarkchurch/contentful-schema-diff"
+       "watermarkchurch/contentful-schema-diff",
+       "watermarkchurch/contentful-shell"
     ]
   }
 ]


### PR DESCRIPTION
https://github.com/watermarkchurch/contentful-shell started as a simple wrapper around our workflow using the Contentful CLI, but then acquired a few more utilities as we went.  Some particularly useful ones:

```
    compare [env]
      Downloads content types and editor interfaces from the given environment
      and compares the structure to the one stored in db/contentful-schema.json.
      If they are different, exits -1 and prints the diff.

    extract <id> [depth] [file]
      downloads the specified entry and all entries & assets that it links to
      down to the specified depth.  The result is a file that can be passed to
      Contentful Import.
      If the file specified is '-', each entry is printed as a stream to STDOUT.
      This makes it easy to pipe to jq.
        * <id> (required) - The ID of the entry to extract
        * [depth] (optional) - Default: 10

    wipe
      Deletes all data in an environment.  You should have a clean environment
      with no entries or content types after this operation.

    new_env
      deletes the current working environment if it exists and makes a new clone of 'master'.
        * -e [to environment ID] (optional) - the current working environment.  Default: $USER
```

It is also very useful when using environment variables to control Contentful access keys.  We use this in combination with [direnv](https://direnv.net/) in order to easily switch Contentful spaces/environments based on current project directory.