### PR TITLE
Add Watermark fork of contentful-migration

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -15,7 +15,8 @@
   {
     "title": "Awesome Utilities",
     "items": [
-       "watermarkchurch/contentful-schema-diff"
+       "watermarkchurch/contentful-schema-diff",
+       "watermarkchurch/contentful-migration
     ]
   }
 ]


### PR DESCRIPTION
At Watermark Church, we have found that the best workflow for managing content type changes in Contentful is to check migration scripts into the repository. This allows us to have them version controlled and only run when the corresponding code is promoted to production. Since we have a directory full of migration scripts, we need a way to control which of them get run. We would like for this to be done as part of our deployment step, similarly to how Rails performs ActiveRecord migrations. To accomplish this we store a history of migrations in our Contentful space, using a content type named "Migration History".

The purpose of this fork is to scan the Migration History in the target contentful space and only apply migrations that do not exist yet in the migration history. This allows us to run the migration tool on every deployment, and it will execute only the necessary migrations.

At least one other person is using this  - @bsgreenb