### PR TITLE
Add watermarkchurch/contentful-ts-generator

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -15,7 +15,8 @@
   {
     "title": "Awesome Utilities",
     "items": [
-       "watermarkchurch/contentful-schema-diff"
+       "watermarkchurch/contentful-schema-diff",
+       "watermarkchurch/contentful-ts-generator"
     ]
   }
 ]


### PR DESCRIPTION
We use https://github.com/watermarkchurch/contentful-ts-generator in our Rails apps to automatically generate typescript types from our Contentful content-types.  We use it as a Webpack plugin, which automatically updates our typescript whenever the schema changes during development.

This allows us to download Contentful entries in our Javascript and automatically cast them to the right types, without having to manually update Typescript definition files.