### PR TITLE
Add wcc-contentful ruby gem

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -21,5 +21,11 @@
       "watermarkchurch/contentful-shell",
       "OriginalEXE/contentmodel.io-web"
     ]
+  },
+  {
+    "title": "Awesome Ruby",
+    "items": [
+      "watermarkchurch/wcc-contentful"
+    ]
   }
 ]


### PR DESCRIPTION
We've created our own Ruby client that we've been using for ~3 years now.  It's been rock solid for the past year and we just cut v1.0 and want to share it with the community.

Why did we create our own Contentful ruby client?  See here: https://github.com/watermarkchurch/wcc-contentful/tree/master/wcc-contentful#why-did-you-rewrite-the-contentful-ruby-stack