### PR TITLE
Add contentful-hugo

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -19,7 +19,8 @@
       "watermarkchurch/contentful-ts-generator",
       "watermarkchurch/contentful-migration",
       "watermarkchurch/contentful-shell",
-      "OriginalEXE/contentmodel.io-web"
+      "OriginalEXE/contentmodel.io-web",
+      "ModiiMedia/contentful-hugo"
     ]
   }
 ]


### PR DESCRIPTION
I've added contentful-hugo to the list of Awesome Utilities.

contentful-hugo is a nodejs cli tool that pulls data from Contentful and saves it as markdown and yaml files for Hugo and other static site generators. It also comes with a server that can be used for local development and content previews.