### PR TITLE
feat: Add contentful-vitesse-starter

### DIFF
--- a/data/awesome-things.json
+++ b/data/awesome-things.json
@@ -10,7 +10,7 @@
   },
   {
     "title": "Awesome Starters",
-    "items": ["whitep4nth3r/thingoftheday", "whitep4nth3r/nextjs-contentful-blog-starter", "canhorn/Blazor.Contentful.Blog.Starter"]
+    "items": ["whitep4nth3r/thingoftheday", "whitep4nth3r/nextjs-contentful-blog-starter", "canhorn/Blazor.Contentful.Blog.Starter", "bcakmakoglu/contentful-vitesse-starter"]
   },
   {
     "title": "Awesome Utilities",


### PR DESCRIPTION
I'd like to submit the contentful-vitesse-starter template to the Awesome Starters list.

This template provides a quick way to get started creating a Contentful App using Vue 3 (+ Vite 2) instead of the default React.
It's based off the default create-contentful-app template and [Vitesse](https://github.com/antfu/vitesse).
It comes with a descriptive README, handy features for a better dev experience, TypeScript and more.

Thank you for considering my PR 💪